### PR TITLE
Comply with standard interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ please at an entry to the "unreleased changes" section below.
 
 ### Unreleased changes
 - Only rely on the default backend for an environment if one was not already declared.
+- Create dummy `batch`, `timer`, `timing`, and `time` functions.
 
 ### Version 2.1.3
 

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -369,6 +369,21 @@ module StatsD
     collect_metric(hash_argument(metric_options).merge(type: :s, name: key, value: value))
   end
 
+  # This is a hack method.  As of right now, we're not concerned with batching
+  # packets to our aggregator, as it's always on the localhost.
+  # If you're interested in having actual batch support on statsd-instrument
+  # please open a pull request.
+  # This is included in order to comply with other interfaces that assume
+  # the batch method is on the interface.
+  def batch
+    yield self
+  end
+
+  # These two methods are to comply with interfaces that other libraries are assuming
+  # are on the StatsD interface
+  alias time measure
+  alias timer measure
+
   private
 
   # Converts old-style ordered arguments in an argument hash for backwards compatibility.

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -383,6 +383,7 @@ module StatsD
   # are on the StatsD interface
   alias time measure
   alias timer measure
+  alias timing measure
 
   private
 

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -379,7 +379,7 @@ module StatsD
     yield self
   end
 
-  # These two methods are to comply with interfaces that other libraries are assuming
+  # These methods are to comply with interfaces that other libraries are assuming
   # are on the StatsD interface
   alias time measure
   alias timer measure


### PR DESCRIPTION
In particular, the Sidekiq StatsD interface is expecting a `batch` and `time` functions on the interface to contact StatsD.  Unfortunately, `statsd-instrument` does not implement them.

For this PR, we're making a dummy `batch` function that simply yields self.  We have no desire at the moment to actually batch calls to the statsd daemon, as we're running telegraf on the localhost.  AFAIK, most situations call for running an aggregator on the localhost, making batching of calls / packets somewhat irrelevant.