### PR TITLE
Add builder pattern for StatsD meta-programming

### DIFF
--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -410,6 +410,131 @@ module StatsD
     backend.collect_metric(metric = StatsD::Instrument::Metric.new(options))
     metric
   end
+
+  # Adds instrumentation to a class via a block.
+  #
+  # The method provides a StatsD::InstrumentBuilder` block parameter which
+  # accepts all metaprogramming methods available on `StatsD::Instrument`.
+  #
+  # @param klass [Class] The class to instrument.
+  # @param singleton [Boolean] Default to using class method for method
+  #   instrumentation.
+  # @yield This method expects a block containing all your StatsD
+  #   instrumentation (see StatsD::InstrumentBuilder).
+  # @yieldparam klass [StatsD::InstrumentBuilder] A StatsD::InstrumentBuilder
+  #   which accepts all metaprogramming methods available on
+  #   `StatsD::Instrument` (see StatsD::InstrumentBuilder).
+  # @return [void]
+  def self.instrument(klass, singleton: false)
+    builder = StatsD::InstrumentBuilder.new(klass, singleton: singleton)
+    yield builder
+  end
+
+  # The StatsD::InstrumentBuilder class provides a wrapper over all existing
+  # metaprogramming methods in `StatsD::Instrument`.
+
+  # This class is used in `StatsD#instrument` to provide a cleaner API for
+  # instrumenting classes via metaprogramming.
+  class InstrumentBuilder
+    # Instantiates a new instrument builder.
+    # @param klass [Class] The class to instrument.
+    # @param singleton [Boolean] Default to using class method for method
+    #   instrumentation.
+    def initialize(klass, singleton: false)
+      klass.extend(Instrument)
+      klass.singleton_class.extend(Instrument)
+      @klass = klass
+      @singleton = singleton
+    end
+
+    # Adds execution duration instrumentation to a method as a timing.
+    #
+    # @param method [Symbol] The name of the method to instrument.
+    # @param name [String, #call] The name of the metric to use. You can also pass in a
+    #    callable to dynamically generate a metric name.
+    # @param class_method [Boolean] Use singleton class (for class methods).
+    # @param metric_options (see StatsD#measure)
+    # @return [void]
+    def measure(method, name, class_method: singleton_class?, **args)
+      klass = class_method ? @klass.singleton_class : @klass
+      klass.statsd_measure(method, name, **args)
+    end
+
+    # Adds execution duration instrumentation to a method as a distribution.
+    #
+    # @param method [Symbol] The name of the method to instrument.
+    # @param name [String, #call] The name of the metric to use. You can also pass in a
+    #    callable to dynamically generate a metric name.
+    # @param class_method [Boolean] Use singleton class (for class methods).
+    # @param metric_options (see StatsD#measure)
+    # @return [void]
+    # @note Supported by the datadog implementation only (in beta)
+    def distribution(method, name, class_method: singleton_class?, **args)
+      klass = class_method ? @klass.singleton_class : @klass
+      klass.statsd_distribution(method, name, **args)
+    end
+
+    # Adds success and failure counter instrumentation to a method.
+    #
+    # A method call will be considered successful if it does not raise an exception, and the result is true-y.
+    # For successful calls, the metric <tt>[name].success</tt> will be incremented; for failed calls, the metric
+    # name is <tt>[name].failure</tt>.
+    #
+    # @param method (see #statsd_measure)
+    # @param name (see #statsd_measure)
+    # @param class_method [Boolean] Use singleton class (for class methods).
+    # @param metric_options (see #statsd_measure)
+    # @yield You can pass a block to this method if you want to define yourself what is a successful call
+    #   based on the return value of the method.
+    # @yieldparam result The return value of the instrumented method.
+    # @yieldreturn [Boolean] Return true iff the return value is considered a success, false otherwise.
+    # @return [void]
+    # @see #statsd_count_if
+    def count_success(method, name, class_method: singleton_class?, **args)
+      klass = class_method ? @klass.singleton_class : @klass
+      klass.statsd_count_success(method, name, **args)
+    end
+
+    # Adds success counter instrumentation to a method.
+    #
+    # A method call will be considered successful if it does not raise an exception, and the result is true-y.
+    # Only for successful calls, the metric will be incremented.
+    #
+    # @param method (see #statsd_measure)
+    # @param name (see #statsd_measure)
+    # @param class_method [Boolean] Use singleton class (for class methods).
+    # @yield (see #statsd_count_success)
+    # @yieldparam result (see #statsd_count_success)
+    # @yieldreturn (see #statsd_count_success)
+    # @return [void]
+    # @see #statsd_count_success
+    def count_if(method, name, class_method: singleton_class?, **args)
+      klass = class_method ? @klass.singleton_class : @klass
+      klass.statsd_count_if(method, name, **args)
+    end
+
+    # Adds counter instrumentation to a method.
+    #
+    # The metric will be incremented for every call of the instrumented method, no matter
+    # whether what the method returns, or whether it raises an exception.
+    #
+    # @param method (see #statsd_measure)
+    # @param name (see #statsd_measure)
+    # @param class_method [Boolean] Use singleton class (for class methods).
+    # @param metric_options (see #statsd_measure)
+    # @return [void]
+    def count(method, name, class_method: singleton_class?, **args)
+      klass = class_method ? @klass.singleton_class : @klass
+      klass.statsd_count(method, name, **args)
+    end
+
+    private
+
+    # @private
+    def singleton_class?
+      @singleton
+    end
+  end
 end
 
 require 'statsd/instrument/version'

--- a/test/statsd_instrument_builder_test.rb
+++ b/test/statsd_instrument_builder_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StatsDInstrumentBuilderTest < Minitest::Test
+  module ActiveMerchant
+    class Base
+      def ssl_post(arg)
+        if arg
+          'OK'
+        else
+          raise 'Not OK'
+        end
+      end
+
+      def post_with_block(&block)
+        block.call if block_given?
+      end
+    end
+
+    class Gateway < Base
+      def purchase(arg)
+        ssl_post(arg)
+        true
+      rescue
+        false
+      end
+
+      def self.sync
+        true
+      end
+    end
+
+    class UniqueGateway < Base
+      def ssl_post(arg)
+        { success: arg }
+      end
+
+      def purchase(arg)
+        ssl_post(arg)
+      end
+    end
+  end
+
+  class GatewaySubClass < ActiveMerchant::Gateway
+    def metric_name
+      'subgateway'
+    end
+  end
+
+  include StatsD::Instrument::Assertions
+
+  def test_statsd_count_if
+    StatsD.instrument(ActiveMerchant::Gateway) do |klass|
+      klass.count_if(:ssl_post, 'ActiveMerchant.Gateway.if')
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.if') do
+      ActiveMerchant::Gateway.new.purchase(true)
+      ActiveMerchant::Gateway.new.purchase(false)
+    end
+  ensure
+    ActiveMerchant::Gateway.statsd_remove_count_if(:ssl_post, 'ActiveMerchant.Gateway.if')
+  end
+
+  def test_statsd_count_if_with_block
+    StatsD.instrument(ActiveMerchant::Gateway) do |klass|
+      klass.count_if(:ssl_post, 'ActiveMerchant.Gateway.if') do |response|
+        response
+      end
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.if') do
+      ActiveMerchant::Gateway.new.purchase(true)
+      ActiveMerchant::Gateway.new.purchase(false)
+    end
+  ensure
+    ActiveMerchant::Gateway.statsd_remove_count_if(:ssl_post, 'ActiveMerchant.Gateway.if')
+  end
+
+  def test_statsd_count_success
+    StatsD.instrument(ActiveMerchant::Gateway) do |klass|
+      klass.count_success(:ssl_post, 'ActiveMerchant.Gateway', sample_rate: 0.5)
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.success', sample_rate: 0.5, times: 1) do
+      ActiveMerchant::Gateway.new.purchase(true)
+      ActiveMerchant::Gateway.new.purchase(false)
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.failure', sample_rate: 0.5, times: 1) do
+      ActiveMerchant::Gateway.new.purchase(false)
+      ActiveMerchant::Gateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::Gateway.statsd_remove_count_success(:ssl_post, 'ActiveMerchant.Gateway')
+  end
+
+  def test_statsd_count
+    StatsD.instrument(ActiveMerchant::Gateway) do |klass|
+      klass.count(:ssl_post, 'ActiveMerchant.Gateway.ssl_post')
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.ssl_post') do
+      ActiveMerchant::Gateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::Gateway.statsd_remove_count(:ssl_post, 'ActiveMerchant.Gateway.ssl_post')
+  end
+
+  def test_statsd_measure
+    StatsD.instrument(ActiveMerchant::UniqueGateway) do |klass|
+      klass.measure(:ssl_post, 'ActiveMerchant.Gateway.ssl_post', sample_rate: 0.3)
+    end
+
+    assert_statsd_measure('ActiveMerchant.Gateway.ssl_post', sample_rate: 0.3) do
+      ActiveMerchant::UniqueGateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::UniqueGateway.statsd_remove_measure(:ssl_post, 'ActiveMerchant.Gateway.ssl_post')
+  end
+
+  def test_instrumenting_class_method
+    StatsD.instrument(ActiveMerchant::Gateway) do |klass|
+      klass.count(:sync, 'ActiveMerchant.Gateway.sync', class_method: true)
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.sync') do
+      ActiveMerchant::Gateway.sync
+    end
+  ensure
+    ActiveMerchant::Gateway.singleton_class.statsd_remove_count(:sync, 'ActiveMerchant.Gateway.sync')
+  end
+
+  def test_instrumenting_class_method_with_singleton_true
+    StatsD.instrument(ActiveMerchant::Gateway, singleton: true) do |klass|
+      klass.count(:sync, 'ActiveMerchant.Gateway.sync')
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.sync') do
+      ActiveMerchant::Gateway.sync
+    end
+  ensure
+    ActiveMerchant::Gateway.singleton_class.statsd_remove_count(:sync, 'ActiveMerchant.Gateway.sync')
+  end
+
+  def test_instrumenting_instance_method_with_singleton_true
+    StatsD.instrument(ActiveMerchant::UniqueGateway, singleton: true) do |klass|
+      klass.count(:ssl_post, 'ActiveMerchant.Gateway.ssl_post', class_method: false)
+    end
+
+    assert_statsd_increment('ActiveMerchant.Gateway.ssl_post') do
+      ActiveMerchant::UniqueGateway.new.purchase(true)
+    end
+  ensure
+    ActiveMerchant::UniqueGateway.statsd_remove_count(:ssl_post, 'ActiveMerchant.Gateway.ssl_post')
+  end
+
+  private
+
+  def assert_scope(klass, method, expected_scope)
+    method_scope = if klass.private_method_defined?(method)
+      :private
+    elsif klass.protected_method_defined?(method)
+      :protected
+    else
+      :public
+    end
+
+    assert_equal(method_scope, expected_scope, "Expected method to be #{expected_scope}")
+  end
+end


### PR DESCRIPTION
See [RFC](https://justworks.atlassian.net/wiki/spaces/ENGG/pages/1051525614/Separating+Business+Logic+from+Instrumentation+StatsD+RFC) for more information.

### New `StatsD.instrument` method

#### Examples
```ruby
StatsD.instrument TokenClient do |klass|
  klass.measure :retrieve!, "TokenClient.retrieve!", class_method: true
  klass.count :retrieve_bulk!, "TokenClient.retrieve_bulk!", class_method: true
  klass.count_if :retrieve_remote_bulk, "TokenClient.retrieve_remote_bulk", class_method: true
end
```
```ruby
# Shorthand for singleton class (all/most static methods)
StatsD.instrument(TokenClient, singleton: true) do |klass|
  klass.measure :retrieve!, "TokenClient.retrieve!"
  klass.count :retrieve_bulk!, "TokenClient.retrieve_bulk!"
  klass.count_if :retrieve_remote_bulk, "TokenClient.retrieve_remote_bulk", class_method: false
end
```